### PR TITLE
t/Parsers.t - use_ok() does not take a test name as an argument

### DIFF
--- a/t/Parsers.t
+++ b/t/Parsers.t
@@ -4,9 +4,9 @@ use warnings;
 use Test::More;
 
 BEGIN {
-    use_ok( 'Devel::Declare::Parser::Sublike', 'sl' );
-    use_ok( 'Devel::Declare::Parser::Codeblock', 'cb' );
-    use_ok( 'Devel::Declare::Parser::Method', 'mth' );
+    use_ok( 'Devel::Declare::Parser::Sublike' );
+    use_ok( 'Devel::Declare::Parser::Codeblock' );
+    use_ok( 'Devel::Declare::Parser::Method' );
     Devel::Declare::Interface::enhance( 'main', $_->[0], $_->[1] )
         for [ 'sl', 'sublike'   ],
             [ 'cb', 'codeblock' ],


### PR DESCRIPTION
use_ok() passes its argument into the use statement, in 5.39.1 passing an argument into a non-existent import statement is an error, but in older perls is silently ignored. This removes the test name from the use_ok() statements